### PR TITLE
upgraded analyzer and build_runner dependencies

### DIFF
--- a/flutter_sheet_localization_generator/pubspec.yaml
+++ b/flutter_sheet_localization_generator/pubspec.yaml
@@ -16,10 +16,10 @@ dependencies:
   source_gen: ^0.9.0
   flutter_sheet_localization: ^2.0.0
   build: ^1.2.0
-  analyzer: ^0.39.0
+  analyzer: '>=0.39.0 <1.0.0'
   collection: ^1.14.11
   intl: ^0.16.1
 
 dev_dependencies:
   build_test: ^0.10.3
-  build_runner: ^1.0.0
+  build_runner: ^1.10.4


### PR DESCRIPTION
- upgraded `analyzer` dependency with version constraints of `>=0.39.0 <1.0.0` and
- upgraded `build_runner` dependency to the latest version which is `^1.10.4`

These changes will solve conflicts with other libraries that use `analyzer` and `build_runner` as their dependency, such as `auto_route_generator`.