### PR TITLE
Upgraded dependencies. (source_gen/dart_style)

### DIFF
--- a/flutter_sheet_localization_generator/pubspec.yaml
+++ b/flutter_sheet_localization_generator/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
   csv: ^5.0.0
   recase: ^4.0.0-nullsafety.0
   code_builder: ^3.7.0
-  dart_style: ^1.0.0
-  source_gen: ^0.9.10
+  dart_style: ^2.0.0
+  source_gen: ^1.0.0
   flutter_sheet_localization: ^3.0.0
   build: ^2.0.0
   analyzer: ^1.2.0


### PR DESCRIPTION
Source Gen 1.0.0 is null-safety now:
https://pub.dev/packages/source_gen/changelog

I've tried to upgrade these dependencies, and Iooks fine.

Could you please merge this? 

Thanks